### PR TITLE
fix(#11): add chalk as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "src/main.js",
   "dependencies": {
-    "inquirer": "^8.2.5"
+    "inquirer": "^8.2.5", 
+    "chalk": "^5.3.0" 
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
### What this PR does
This PR adds `chalk` to the project's dependencies in package.json.  

Previously, `chalk` was used in `examSimulator.js` and `main.js` but not listed as a dependency. It worked only because it was pulled in as a transitive dependency, which is fragile and can break in the future if the indirect dependency changes.  

### Changes
- Added `"chalk": "^5.3.0"` to `"dependencies"` in package.json
- Verified imports in JS files remain correct
- Ensured `npm install` installs Chalk correctly

### Why is this needed
Declaring `chalk` explicitly ensures:
- The project does not break due to changes in transitive dependencies
- Anyone cloning the repo can install all required dependencies reliably

### Related issue
Closes #11